### PR TITLE
Scaffold core models and CRUD API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+/tmp/

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+from typing import Dict
+
+from fastapi import FastAPI, HTTPException
+
+from .models import ActivityEvent, Task
+from .username_generator import generate_username
+
+app = FastAPI(title="Liahona")
+
+tasks: Dict[str, Task] = {}
+
+
+@app.post("/users/signup")
+def signup(gender: str, email: str):
+    user_id = generate_username(gender, datetime.utcnow())
+    return {"user_id": user_id, "role": "steward"}
+
+
+@app.post("/tasks", response_model=Task)
+def create_task(task: Task):
+    if task.id in tasks:
+        raise HTTPException(status_code=400, detail="Task exists")
+    task.activity_log.append(ActivityEvent(event="create", by=task.created_by))
+    tasks[task.id] = task
+    return task
+
+
+@app.get("/tasks/{task_id}", response_model=Task)
+def read_task(task_id: str):
+    task = tasks.get(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Not found")
+    return task
+
+
+@app.put("/tasks/{task_id}", response_model=Task)
+def update_task(task_id: str, updated: Task):
+    if task_id not in tasks:
+        raise HTTPException(status_code=404, detail="Not found")
+    updated.activity_log = tasks[task_id].activity_log + [ActivityEvent(event="update", by=updated.created_by)]
+    tasks[task_id] = updated
+    return updated
+
+
+@app.delete("/tasks/{task_id}")
+def delete_task(task_id: str):
+    task = tasks.get(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Not found")
+    task.activity_log.append(ActivityEvent(event="delete", by=task.created_by))
+    del tasks[task_id]
+    return {"status": "deleted"}
+
+
+@app.get("/tasks/{task_id}/activity")
+def task_activity(task_id: str):
+    task = tasks.get(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Not found")
+    return task.activity_log
+

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class TaskStatus(str, Enum):
+    activity = "activity"
+    accepted = "accepted"
+    action = "action"
+    submitted = "submitted"
+    confirmed = "confirmed"
+    sealed = "sealed"
+    expired = "expired"
+    abandoned = "abandoned"
+    forked = "forked"
+
+
+class SLA(BaseModel):
+    phase: TaskStatus = TaskStatus.activity
+    due_at: Optional[datetime] = None
+    extended_days: int = 0
+
+
+class Deliverable(BaseModel):
+    id: str
+    type: str  # file|link|text
+    url: str
+    uploaded_by: str
+
+
+class Comment(BaseModel):
+    id: str
+    author_id: str
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    body: str
+    mentions: List[str] = []
+    refs: List[str] = []
+    pinned: bool = False
+
+
+class ActivityEvent(BaseModel):
+    event: str
+    by: str
+    ts: datetime = Field(default_factory=datetime.utcnow)
+    metadata: dict = {}
+
+
+class Task(BaseModel):
+    id: str
+    project_id: str
+    title: str
+    status: TaskStatus = TaskStatus.activity
+    created_by: str
+    owner_id: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    accepted_at: Optional[datetime] = None
+    sla: SLA = Field(default_factory=SLA)
+    acceptance_criteria: Optional[str] = None
+    deliverables: List[Deliverable] = []
+    comments: List[Comment] = []
+    activity_log: List[ActivityEvent] = []
+
+
+class User(BaseModel):
+    id: str
+    gender: str
+    email: str
+
+
+class Project(BaseModel):
+    id: str
+    title: str
+    owner_id: str
+

--- a/app/username_generator.py
+++ b/app/username_generator.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from hashlib import sha256
+from typing import Dict
+
+MALE_NAMES = [
+    "adam", "abel", "enos", "noah", "moses", "abraham", "isaac", "jacob",
+    "lehi", "nephi", "alma", "helaman", "mormon", "moroni",
+]
+FEMALE_NAMES = [
+    "eve", "sarah", "rebecca", "ruth", "mary", "martha", "sariah",
+    "abish", "isabel", "rhoda", "emma", "phoebe", "naomi",
+]
+
+existing_usernames: Dict[str, str] = {}
+
+
+def generate_username(gender: str, signup_date: datetime) -> str:
+    names = MALE_NAMES if gender.lower() == "male" else FEMALE_NAMES
+    key = f"{gender}:{signup_date.isoformat()}"
+    digest = sha256(key.encode()).hexdigest()
+    index = int(digest, 16) % len(names)
+    base_name = names[index]
+    username = base_name
+    counter = 1
+    while username in existing_usernames:
+        counter += 1
+        username = f"{base_name}{counter}"
+    existing_usernames[username] = key
+    return username
+

--- a/cursorrules.md
+++ b/cursorrules.md
@@ -1,0 +1,151 @@
+# Cursor Rules
+
+This document enumerates build tasks, subtasks, and testing methodology for each milestone described in the project README. The intent is to guide contributors and automation tools such as Cursor when building the system.
+
+## Milestone 1 — Core Data Model & Storage (Week 1–2)
+
+### Development Tasks
+1. **Schema Definitions**
+   - Create `Task`, `User`, and `Project` models with required fields and types.
+   - Include status enums and nested structures (`activity_log`, `sla`, `deliverables`).
+   - Set up database indices for common query patterns (by project, owner, status).
+2. **Scripture-based Auto-Username Generator**
+   - Accept gender and signup date to deterministically generate a username.
+   - Ensure uniqueness; append numeric suffix if collision occurs.
+3. **Task CRUD Endpoints**
+   - `POST /tasks` to create tasks.
+   - `GET /tasks/{id}` to retrieve.
+   - `PUT /tasks/{id}` to update.
+   - `DELETE /tasks/{id}` to soft-delete or mark abandoned.
+4. **Append-only `activity_log`**
+   - Record all state changes with user ID, timestamp, and metadata.
+   - Expose `GET /tasks/{id}/activity` to fetch history.
+
+### Testing Methodology
+- Unit tests for each model validating required fields and default values.
+- Unit tests for username generator covering gender/date combinations and collision handling.
+- Integration tests for CRUD endpoints using FastAPI `TestClient` or similar.
+- Database tests verifying `activity_log` only appends and never mutates existing entries.
+- Run `pytest` to execute the suite.
+
+## Milestone 2 — Primitive Endpoints (Week 2–3)
+
+### Development Tasks
+1. **Implement the Six Primitive Endpoints**
+   - `publish`, `accept`, `action`, `submit`, `confirm`, `seal` routes.
+   - Define request/response schemas for each endpoint.
+   - Record transitions in `activity_log`.
+2. **Atomic Task Enforcement**
+   - Validate task titles contain a single verb using heuristic or NLP check.
+   - If multiple verbs detected, invoke Brain service to propose split tasks.
+3. **Status Transition Guard**
+   - Ensure tasks move only through allowed transitions (e.g., `activity` → `accepted`).
+
+### Testing Methodology
+- Integration tests calling each primitive endpoint and verifying status changes.
+- Negative tests ensuring invalid transitions return errors.
+- Mock Brain service for atomicity checks.
+- Run `pytest` for unit and integration tests.
+
+## Milestone 3 — SLA & Automation Layer (Week 3–4)
+
+### Development Tasks
+1. **SLA Timer Implementation**
+   - Start 7-day countdown on key events (`accept`, `submit`, `confirm`).
+   - Store next due date inside task `sla` object.
+2. **Auto-expiration**
+   - Background job scans for overdue tasks and sets status to `expired`.
+3. **SLA Extension**
+   - Allow steward to extend due date once by +3 or +7 days.
+4. **Auto-generated Fix Tasks**
+   - When a task receives `changes_requested`, spawn child task `task_{id}_fixN` with updated criteria.
+
+### Testing Methodology
+- Unit tests for SLA calculations ensuring correct due dates.
+- Simulated time progression tests validating auto-expire behavior.
+- Integration tests for extension flow and fix-task generation.
+- Run `pytest` with time-freezing utilities (e.g., `freezegun`).
+
+## Milestone 4 — Comments & Collaboration (Week 4–5)
+
+### Development Tasks
+1. **Comments Endpoint**
+   - `POST /tasks/{id}/comments` to add comment bodies supporting `@mentions`, `#refs`, and `pinned` flag.
+   - `GET /tasks/{id}/comments` to list.
+2. **Notification System**
+   - On `@mention` or SLA expiry, enqueue notification for the affected user.
+   - Provide `GET /notifications` endpoint.
+3. **Activity Feed Rendering**
+   - Aggregate `activity_log` and comments into chronological feed for UI consumption.
+
+### Testing Methodology
+- Unit tests parsing mentions and refs from comment bodies.
+- Integration tests for comment creation and retrieval endpoints.
+- Mock notification transport and verify triggers.
+- Run `pytest` to execute all tests.
+
+## Milestone 5 — Frontend Split‑Pane UI (Week 5–7)
+
+### Development Tasks
+1. **Activity Tree Panel**
+   - Build project → tasks → subtasks tree with expand/collapse and drag‑to‑reorder within parent.
+   - Show badges for counts and SLA risk state.
+2. **Chat-first Task View**
+   - Combine task details with chat thread, deliverables, and primitive action buttons.
+   - Display typing indicators and live updates via WebSocket or SSE.
+3. **Brain Tab**
+   - Provide chat interface to Brain for context and next-step suggestions.
+4. **Theme and Layout**
+   - Dark theme default; responsive two-pane design; code-block formatting.
+
+### Testing Methodology
+- Component tests with React Testing Library verifying rendering and interactions.
+- End-to-end tests with Playwright covering task acceptance, commenting, and sealing flows.
+- Accessibility checks using `axe` or similar tools.
+
+## Milestone 6 — Brain Integration (Week 7–8)
+
+### Development Tasks
+1. **Data Ingestion Connectors**
+   - Parse domain emails/docs and store embeddings in Qdrant.
+2. **Bootstrap Task Tree**
+   - Generate initial tasks from a vision statement.
+3. **Split Compound Tasks**
+   - Detect multiple verbs and atomize into subtasks.
+4. **Suggest Next Activities**
+   - After sealing, propose follow-up activities.
+5. **Brain Chat**
+   - Allow stewards to query Brain for contextual help.
+6. **Admin Approval UI**
+   - Interface for superadmin to approve or decline AI-suggested tasks.
+
+### Testing Methodology
+- Unit tests for ingestion pipeline and embedding creation.
+- Integration tests mocking OpenAI/Qdrant interactions.
+- E2E tests verifying AI-suggested tasks appear and can be approved or declined.
+- Run `pytest` and Playwright suites.
+
+## Milestone 7 — Deployment & Governance (Week 8–9)
+
+### Development Tasks
+1. **Deployment Pipeline**
+   - Dockerize backend and frontend.
+   - Deploy backend (e.g., Render) and frontend (e.g., Vercel).
+2. **Superadmin Dashboard**
+   - View/manage all tasks, force expire/abandon, approve extensions, confirm tasks.
+3. **Immutable Sealing**
+   - Generate hashes for approved tasks and store in tamper-proof log.
+
+### Testing Methodology
+- CI pipeline executing `pytest`, frontend tests, and linting on every push.
+- Smoke tests post-deployment to verify health endpoints and core flows.
+- Security tests ensuring sealed hashes cannot be modified.
+
+---
+
+## Global Testing Guidelines
+- All milestones should maintain 90%+ code coverage.
+- Run `pytest` for backend and `npm test` for frontend regularly.
+- Use CI to enforce formatting (e.g., `black`, `eslint`) and type checks (`mypy`, `tsc`).
+- Document manual test cases for features without automation.
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pydantic
+pytest
+httpx

--- a/tests/test_task_crud.py
+++ b/tests/test_task_crud.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models import Task
+
+client = TestClient(app)
+
+
+def test_create_read_task():
+    payload = {
+        "id": "t1",
+        "project_id": "p1",
+        "title": "Test Task",
+        "created_by": "u1",
+    }
+    resp = client.post("/tasks", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == "t1"
+
+    resp = client.get("/tasks/t1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["title"] == "Test Task"
+
+
+def test_update_delete_task():
+    payload = {
+        "id": "t2",
+        "project_id": "p1",
+        "title": "Another Task",
+        "created_by": "u1",
+    }
+    client.post("/tasks", json=payload)
+
+    payload["title"] = "Updated Task"
+    resp = client.put("/tasks/t2", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Updated Task"
+
+    resp = client.delete("/tasks/t2")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "deleted"
+

--- a/tests/test_username.py
+++ b/tests/test_username.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+from app.username_generator import generate_username, existing_usernames
+
+
+def test_username_deterministic():
+    date = datetime(2023, 1, 1)
+    u1 = generate_username("male", date)
+    existing_usernames.clear()
+    u2 = generate_username("male", date)
+    assert u1 == u2
+
+
+def test_username_uniqueness():
+    date = datetime(2023, 1, 2)
+    u1 = generate_username("female", date)
+    u2 = generate_username("female", date)
+    assert u1 != u2
+


### PR DESCRIPTION
## Summary
- define Pydantic models for tasks, users, projects and supporting enums
- implement deterministic scripture-style username generator
- expose FastAPI endpoints for user signup and basic task CRUD with activity log
- add unit tests for username generator and task CRUD

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b66261de3c8333ad36b7a56056e3c1